### PR TITLE
Add route corridor filtering and scheduled reloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+*.log
+*.tmp
+*.bak
+*.swp
+.DS_Store
+Thumbs.db

--- a/MMM-Autobahn.js
+++ b/MMM-Autobahn.js
@@ -1,30 +1,46 @@
 Module.register("MMM-Autobahn", {
-    // Default module config.
+
     defaults: {
-        reloadInterval: 1000 * 60 * 15,
+        /*
+         * Normal reload interval.
+         */
+        reloadInterval: 1000 * 60 * 30,
+
+        /*
+         * Optional time-based reload intervals.
+         *
+         * Example:
+         * 05:00 - 07:00 every 5 minutes,
+         * otherwise reloadInterval is used.
+         */
+        reloadSchedule: [],
+
         logo_right: false,
-        roads: [
-            {
-                road: "A5",
-                from: 10,
-                to: 22
-            }
-        ]
+
+        /*
+         * Limit long API descriptions so the module
+         * does not overlap neighbouring modules.
+         */
+        maxDescriptionLines: 3,
+
+        roads: []
     },
 
     start: function () {
         Log.info("Starting module: " + this.name);
+
         this.roadData = [];
         this.loaded = false;
+        this.error = false;
+        this.reloadTimer = null;
     },
 
     getStyles: function () {
         return ["autobahn.css"];
     },
 
-    // Override dom generator.
     getDom: function () {
-        var wrapper = document.createElement("div");
+        const wrapper = document.createElement("div");
         wrapper.id = "autobahn";
 
         if (!this.loaded) {
@@ -33,27 +49,44 @@ Module.register("MMM-Autobahn", {
             return wrapper;
         }
 
-        if (!this.roadData || this.roadData.length == 0) {
+        if (this.error) {
+            wrapper.innerHTML = "Datenabruf fehlgeschlagen";
+            wrapper.className = "dimmed light small";
+            return wrapper;
+        }
+
+        if (!this.roadData || this.roadData.length === 0) {
             wrapper.innerHTML = "Keine aktuellen Meldungen";
             wrapper.className = "dimmed light small";
             return wrapper;
         }
 
         this.roadData.forEach(warning => {
-            let div = document.createElement("div");
+
+            const div = document.createElement("div");
             div.classList.add("autobahn-report-element");
 
-            let title = document.createElement("div");
+            /*
+             * Header
+             */
+            const title = document.createElement("div");
             title.classList.add("autobahn-report-title");
 
-            let roadSign = document.createElement("span");
-            roadSign.id = 'road-sign';
+            const roadSign = document.createElement("span");
+            roadSign.classList.add("road-sign");
 
-            roadSign.innerText = warning.road.substring(1);
+            roadSign.innerText =
+                warning.road?.startsWith("A")
+                    ? warning.road.substring(1)
+                    : warning.road || "";
 
-            let subtitle = document.createElement("span");
-            subtitle.classList.add("autobahn-report-subtitle")
-            subtitle.innerText = warning.subtitle;
+            const subtitle = document.createElement("span");
+            subtitle.classList.add("autobahn-report-subtitle");
+
+            subtitle.innerText =
+                warning.subtitle ||
+                warning.title ||
+                "";
 
             if (!this.config.logo_right) {
                 title.appendChild(roadSign);
@@ -62,42 +95,133 @@ Module.register("MMM-Autobahn", {
                 title.appendChild(subtitle);
                 title.appendChild(roadSign);
             }
+
             div.appendChild(title);
 
+            /*
+             * Full road closure
+             */
+            if (
+                warning.isBlocked === "true" ||
+                warning.isBlocked === true
+            ) {
+                const blocked =
+                    document.createElement("div");
 
-            let body = document.createElement("span");
-            for (let i = 0; i < warning.description.length; i++) {
-                line = warning.description[i];
+                blocked.classList.add("blocked");
+                blocked.innerText = "VOLLSPERRUNG";
 
-                if (line && !line.startsWith("Beginn:") && !line.startsWith("Ende:") && !line.match(/^A\d+/)) {
-                    if (line.startsWith("Länge:")) {
+                div.appendChild(blocked);
+            }
 
-                        let length = new Number(line.match(/\d+.?\d*/)[0]);
-                        length = Math.round(length);
-                        console.log(length);
+            /*
+             * Warning description
+             */
+            const body = document.createElement("div");
+            body.classList.add("autobahn-report-body");
 
-                        jamLength = document.createElement("div");
-                        jamLength.classList.add("jam-length");
+            let shownLines = 0;
 
-                        if (warning.isBlocked === "true") {
-                            blocked = document.createElement("span");
-                            blocked.classList.add("blocked");
-                            blocked.innerText = "VOLLSPERRUNG";
-                            jamLength.appendChild(blocked);
-                        }
+            const description =
+                Array.isArray(warning.description)
+                    ? warning.description
+                    : [];
 
-                        let jamImg = document.createElement("img");
-                        jamImg.src = "/MMM-Autobahn/jam.png";
-                        jamImg.classList.add("jam-icon");
+            for (const rawLine of description) {
+
+                if (!rawLine) {
+                    continue;
+                }
+
+                const line =
+                    String(rawLine).trim();
+
+                if (!line) {
+                    continue;
+                }
+
+                /*
+                 * Hide redundant technical information.
+                 */
+                if (
+                    line.startsWith("Beginn:") ||
+                    line.startsWith("Ende:") ||
+                    /^A\d+\s*$/.test(line)
+                ) {
+                    continue;
+                }
+
+                /*
+                 * Display traffic jam length separately.
+                 */
+                if (line.startsWith("Länge:")) {
+
+                    const lengthMatch =
+                        line.match(/\d+(?:[.,]\d+)?/);
+
+                    if (lengthMatch) {
+
+                        const jamLength =
+                            document.createElement("div");
+
+                        jamLength.classList.add(
+                            "jam-length"
+                        );
+
+                        const jamImg =
+                            document.createElement("img");
+
+                        jamImg.src =
+                            "/MMM-Autobahn/jam.png";
+
+                        jamImg.classList.add(
+                            "jam-icon"
+                        );
+
                         jamLength.appendChild(jamImg);
 
-                        jamLength.innerHTML += length + " km";
+                        const km =
+                            Number(
+                                lengthMatch[0]
+                                    .replace(",", ".")
+                            );
+
+                        jamLength.appendChild(
+                            document.createTextNode(
+                                ` ${Math.round(km)} km`
+                            )
+                        );
+
                         div.appendChild(jamLength);
                     }
-                    else body.innerHTML += line + "<br />";
+
+                    continue;
                 }
+
+                if (
+                    shownLines >=
+                    this.config.maxDescriptionLines
+                ) {
+                    break;
+                }
+
+                const lineDiv =
+                    document.createElement("div");
+
+                lineDiv.classList.add(
+                    "autobahn-description-line"
+                );
+
+                lineDiv.innerText = line;
+
+                body.appendChild(lineDiv);
+
+                shownLines++;
             }
-            div.appendChild(body);
+
+            if (shownLines > 0) {
+                div.appendChild(body);
+            }
 
             wrapper.appendChild(div);
         });
@@ -105,42 +229,266 @@ Module.register("MMM-Autobahn", {
         return wrapper;
     },
 
-    notificationReceived: function (notification, payload, sender) {
-        switch (notification) {
-            case "DOM_OBJECTS_CREATED":
-                //Update the data, after creating
-                this.sendSocketNotification("GET_AUTOBAHN_DATA",
-                    {
-                        "config": this.config,
-                        "identifier": this.identifier
-                    }
-                )
-                //Start timer for update
-                var timer = setInterval(() => {
-                    this.sendSocketNotification("GET_AUTOBAHN_DATA",
-                        {
-                            "config": this.config,
-                            "identifier": this.identifier
-                        }
-                    )
-                }, this.config.reloadInterval);
-                break;
+    notificationReceived: function (notification) {
+
+        if (notification !== "DOM_OBJECTS_CREATED") {
+            return;
         }
+
+        /*
+         * Initial request immediately after startup.
+         */
+        this.requestData();
+
+        /*
+         * Then use the dynamic scheduler.
+         */
+        this.scheduleNextUpdate();
     },
 
-    socketNotificationReceived: function (notification, payload) {
-        switch (notification) {
-            case "AUTOBAHN_DATA":
-                this.roadData = payload;
-                this.roadData.lastUpdate = "";
-                this.loaded = true;
-                console.log("test");
-                this.updateDom();
-                break;
-            case "AUTOBAHN_DATA_ERROR":
-                this.data = [];
-                //ToDo Error Handling to user
-                break;
+    requestData: function () {
+
+        this.sendSocketNotification(
+            "GET_AUTOBAHN_DATA",
+            {
+                config: this.config,
+                identifier: this.identifier
+            }
+        );
+    },
+
+    scheduleNextUpdate: function () {
+
+        if (this.reloadTimer) {
+            clearTimeout(this.reloadTimer);
+        }
+
+        const now = new Date();
+
+        const interval =
+            this.getCurrentReloadInterval(now);
+
+        /*
+         * Do not sleep beyond a schedule boundary.
+         *
+         * Example:
+         * At 04:55 with a normal 30 minute interval,
+         * wake up at 05:00 instead of 05:25.
+         */
+        const boundaryDelay =
+            this.getMillisecondsUntilNextScheduleBoundary(
+                now
+            );
+
+        let delay = interval;
+
+        if (
+            Number.isFinite(boundaryDelay) &&
+            boundaryDelay > 0
+        ) {
+            delay =
+                Math.min(
+                    interval,
+                    boundaryDelay
+                );
+        }
+
+        this.reloadTimer =
+            setTimeout(
+                () => {
+                    this.requestData();
+                    this.scheduleNextUpdate();
+                },
+                delay
+            );
+    },
+
+    getCurrentReloadInterval: function (now) {
+
+        const schedule =
+            Array.isArray(this.config.reloadSchedule)
+                ? this.config.reloadSchedule
+                : [];
+
+        const currentMinutes =
+            now.getHours() * 60 +
+            now.getMinutes();
+
+        for (const entry of schedule) {
+
+            const start =
+                this.timeToMinutes(entry.start);
+
+            const end =
+                this.timeToMinutes(entry.end);
+
+            const interval =
+                Number(entry.reloadInterval);
+
+            if (
+                start === null ||
+                end === null ||
+                !Number.isFinite(interval) ||
+                interval <= 0
+            ) {
+                continue;
+            }
+
+            /*
+             * Normal interval, e.g. 05:00 - 07:00.
+             */
+            if (start < end) {
+
+                if (
+                    currentMinutes >= start &&
+                    currentMinutes < end
+                ) {
+                    return interval;
+                }
+            }
+
+            /*
+             * Interval crossing midnight,
+             * e.g. 22:00 - 02:00.
+             */
+            else if (start > end) {
+
+                if (
+                    currentMinutes >= start ||
+                    currentMinutes < end
+                ) {
+                    return interval;
+                }
+            }
+
+            /*
+             * start === end means 24 hours.
+             */
+            else {
+                return interval;
+            }
+        }
+
+        return this.config.reloadInterval;
+    },
+
+    getMillisecondsUntilNextScheduleBoundary: function (now) {
+
+        const schedule =
+            Array.isArray(this.config.reloadSchedule)
+                ? this.config.reloadSchedule
+                : [];
+
+        if (schedule.length === 0) {
+            return Infinity;
+        }
+
+        let shortestDelay = Infinity;
+
+        for (const entry of schedule) {
+
+            for (const time of [entry.start, entry.end]) {
+
+                const minutes =
+                    this.timeToMinutes(time);
+
+                if (minutes === null) {
+                    continue;
+                }
+
+                const target =
+                    new Date(now);
+
+                target.setHours(
+                    Math.floor(minutes / 60),
+                    minutes % 60,
+                    0,
+                    0
+                );
+
+                /*
+                 * Boundary already passed today:
+                 * use tomorrow.
+                 */
+                if (target <= now) {
+                    target.setDate(
+                        target.getDate() + 1
+                    );
+                }
+
+                const delay =
+                    target.getTime() -
+                    now.getTime();
+
+                shortestDelay =
+                    Math.min(
+                        shortestDelay,
+                        delay
+                    );
+            }
+        }
+
+        return shortestDelay;
+    },
+
+    timeToMinutes: function (value) {
+
+        if (
+            typeof value !== "string" ||
+            !/^\d{2}:\d{2}$/.test(value)
+        ) {
+            return null;
+        }
+
+        const parts =
+            value.split(":");
+
+        const hours =
+            Number(parts[0]);
+
+        const minutes =
+            Number(parts[1]);
+
+        if (
+            !Number.isInteger(hours) ||
+            !Number.isInteger(minutes) ||
+            hours < 0 ||
+            hours > 23 ||
+            minutes < 0 ||
+            minutes > 59
+        ) {
+            return null;
+        }
+
+        return hours * 60 + minutes;
+    },
+
+    socketNotificationReceived: function (
+        notification,
+        payload
+    ) {
+
+        if (notification === "AUTOBAHN_DATA") {
+
+            this.roadData =
+                Array.isArray(payload)
+                    ? payload
+                    : [];
+
+            this.loaded = true;
+            this.error = false;
+
+            this.updateDom();
+        }
+
+        if (notification === "AUTOBAHN_DATA_ERROR") {
+
+            this.roadData = [];
+            this.loaded = true;
+            this.error = true;
+
+            this.updateDom();
         }
     }
+
 });

--- a/README.md
+++ b/README.md
@@ -1,75 +1,217 @@
 # MMM-Autobahn
-**This is a BETA Test! Please report any issues.**
 
-MMM-Autobahn is a simple module which shows traffic-warnings on defined roads and sectors of the german Autobahn network. It uses the official **Autobahn App API** (https://autobahn.api.bund.dev/)
+MMM-Autobahn is a MagicMirror² module for displaying current traffic warnings from the German Autobahn network.
+
+This repository is based on the original project by [JockeyDoe](https://github.com/JockeyDoe/MMM-Autobahn). The current enhancements adapt the module to changes in the Autobahn API and add route-based filtering, scheduled update intervals, and a more compact display.
+
+> The module uses the official Autobahn traffic API at `https://verkehr.autobahn.de/o/autobahn/`.
+
+## Features
+
+- Display current traffic warnings for selected Autobahn roads
+- Filter warnings by a configurable route corridor
+- Use the API's GeoJSON `LineString` geometry where available
+- Fall back to a warning's single coordinate if no geometry is available
+- Keep legacy `from` / `to` filtering for backwards compatibility
+- Configure time-based reload intervals
+- Limit long warning descriptions to avoid overlapping neighbouring MagicMirror modules
+- Distinguish between "no current warnings" and an API request failure
 
 ## Preview
 
 ![Example](screenshot2.jpg)
 
 ## Installation
-Go the modules folder of your Mirror
+
+Go to the MagicMirror modules directory:
+
 ```shell
-cd ~/Magic-Mirror/modules/
+cd ~/MagicMirror/modules/
 ```
-Clone the repository and install the dependencies
+
+Clone the repository and install the dependencies:
+
 ```shell
-git clone https://github.com/JockeyDoe/MMM-Autobahn
+git clone https://github.com/JockeyDoe/MMM-Autobahn.git
 cd MMM-Autobahn
 npm install
 ```
-## Config File
-Open your config file and add the module
 
-*Sample*
+Then add the module to your MagicMirror `config/config.js`.
+
+## Basic configuration
+
 ```javascript
-//... other modules
 {
-	module: 'MMM-Autobahn',
-	header: 'Verkehrsmeldungen',
-	position: "top_right",
-	config: {
-		reloadInterval: 1000 * 60 * 15, 
-		logo_right: false,
-		roads: [
-			{
-				road: "A5",
-				from: 10,
-				to: 22
-			},
-			{
-				road: "A45"
-			}
-		]
-	}
-},
-//other modules ...
+    module: "MMM-Autobahn",
+    header: "Verkehrsmeldungen",
+    position: "top_right",
+
+    config: {
+        reloadInterval: 1000 * 60 * 30,
+        logo_right: false,
+        maxDescriptionLines: 3,
+
+        roads: [
+            {
+                road: "A7"
+            },
+            {
+                road: "A26"
+            }
+        ]
+    }
+}
 ```
-Description of the config fields
-|Option|Default|Description|
-|--|--|--|
-|```reloadInterval```|```1000 * 60 * 15```|Number of ms until a reload of the warning data is performed. Do not fall below 5 minutes.|
-|```logo_right```|```false```|Decides whether the logo of the road is displayed left or right of the warning title|
-|```roads```||Road objects to fetch and display|
-|```road```|```"A5"```|Name of an Autobahn road to fetch. Possible values can be found here: https://verkehr.autobahn.de/o/autobahn/|
-|```from``` *(optional)*|```10```|The number of the exit or crossing from which the warnings should be displayed. Can be found on Google Maps or in the Autobahn-Atlas http://www.autobahnatlas-online.de/ (recommended)|
-|```to``` *(optional)*|```22```|see "```from```"
 
-If ```from``` or ```to``` are not defined the module will display the whole road. (This is **not** recommended for long roads with one or two digits f.e. "A7" or "A38")
+## Configuration options
 
+| Option | Default | Description |
+|---|---:|---|
+| `reloadInterval` | `1000 * 60 * 30` | Normal reload interval in milliseconds. |
+| `reloadSchedule` | `[]` | Optional list of time windows with alternative reload intervals. |
+| `logo_right` | `false` | Display the Autobahn sign on the right side of the warning title. |
+| `maxDescriptionLines` | `3` | Maximum number of normal description lines shown per warning. |
+| `roads` | `[]` | Autobahn road definitions to fetch and display. |
+| `road` | — | Autobahn name, for example `"A7"`. |
+| `route` | — | Optional array of route points containing `lat` and `long`. |
+| `corridorKm` | `4` | Maximum distance in kilometres between a warning and the configured route. |
+| `from` | — | Legacy junction-number filter. Kept for backwards compatibility. |
+| `to` | — | Legacy junction-number filter. Kept for backwards compatibility. |
 
-## Route based filtering
+## Route-based filtering
 
-The Autobahn API no longer reliably includes junction numbers in warning titles.
-For this reason, `from` and `to` can no longer be used reliably for all roads.
+The current Autobahn API no longer reliably includes junction numbers in warning titles. A warning may now have a title such as:
 
-As an alternative, MMM-Autobahn can filter warnings by a configurable route corridor.
+```text
+A7 | Verkehrsmeldung
+```
 
-A route is defined as a list of latitude/longitude points. The module checks the
-geometry returned by the Autobahn API and only keeps warnings that are within
-the configured corridor.
+This makes the old `from` / `to` filter unreliable for many roads.
 
-Example:
+MMM-Autobahn therefore supports filtering against a route polyline. The route consists of two or more latitude/longitude points. A warning is displayed when at least one point of its API geometry lies within the configured corridor.
+
+Example for a section of the A7:
+
+```javascript
+roads: [
+    {
+        road: "A7",
+        corridorKm: 4,
+
+        route: [
+            { lat: 53.5220, long: 9.9260 },
+            { lat: 53.4700, long: 9.9500 },
+            { lat: 53.4094, long: 9.9931 },
+            { lat: 53.3837, long: 10.0184 },
+            { lat: 53.3464, long: 10.0383 }
+        ]
+    }
+]
+```
+
+Additional route points can be used to follow curves, motorway rings, or other non-linear road sections. This avoids the limitations of a simple rectangular geographic filter.
+
+### Coordinate format
+
+The Autobahn API returns route geometry as GeoJSON. GeoJSON coordinates use this order:
+
+```text
+[longitude, latitude]
+```
+
+The module converts them internally to:
+
+```javascript
+{
+    lat: 53.5220,
+    long: 9.9260
+}
+```
+
+If a warning does not contain a `LineString` geometry, the module falls back to `warning.coordinate`.
+
+## Legacy `from` / `to` filtering
+
+Existing configurations using junction-number filters remain supported:
+
+```javascript
+roads: [
+    {
+        road: "A5",
+        from: 10,
+        to: 22
+    }
+]
+```
+
+However, the current API does not reliably provide junction numbers in warning titles. For new configurations, `route` together with `corridorKm` is recommended.
+
+If neither a route nor a legacy range is configured, all current warnings for the selected road are displayed.
+
+## Time-based reload intervals
+
+`reloadInterval` defines the normal update interval. Optional time windows can override it.
+
+Example: update every 5 minutes between 05:00 and 07:00, otherwise every 30 minutes:
+
+```javascript
+reloadInterval: 1000 * 60 * 30,
+
+reloadSchedule: [
+    {
+        start: "05:00",
+        end: "07:00",
+        reloadInterval: 1000 * 60 * 5
+    }
+]
+```
+
+The scheduler also observes the start and end of each time window. For example, if a normal 30-minute cycle would run from 04:50 to 05:20, the module wakes at 05:00 and switches to the 5-minute interval instead of waiting until 05:20.
+
+Multiple schedule entries are supported. Time windows crossing midnight are supported as well:
+
+```javascript
+reloadSchedule: [
+    {
+        start: "22:00",
+        end: "02:00",
+        reloadInterval: 1000 * 60 * 10
+    }
+]
+```
+
+Each schedule entry uses local system time.
+
+## Compact warning display
+
+Some warnings returned by the current API contain long descriptions. `maxDescriptionLines` limits the amount of normal description text shown for each warning:
+
+```javascript
+maxDescriptionLines: 3
+```
+
+Traffic-jam length and full road-closure information are displayed separately and are not counted as normal description lines.
+
+The module CSS also limits the module width and hides overflow to reduce the risk of traffic warnings overlapping neighbouring MagicMirror modules.
+
+## API request handling
+
+Traffic data is fetched from:
+
+```text
+https://verkehr.autobahn.de/o/autobahn/{ROAD}/services/warning
+```
+
+Requests use a 60-second timeout because the Autobahn API can occasionally respond slowly.
+
+The display differentiates between these states:
+
+- `Lade ...` — initial request still running
+- `Keine aktuellen Meldungen` — request succeeded, but no warning matched the configured roads or route filters
+- `Datenabruf fehlgeschlagen` — traffic data could not be retrieved
+
+## Example: route filter plus scheduled updates
 
 ```javascript
 {
@@ -95,7 +237,6 @@ Example:
             {
                 road: "A7",
                 corridorKm: 4,
-
                 route: [
                     { lat: 53.5220, long: 9.9260 },
                     { lat: 53.4700, long: 9.9500 },
@@ -104,10 +245,29 @@ Example:
                     { lat: 53.3464, long: 10.0383 }
                 ]
             },
-
             {
                 road: "A26"
             }
         ]
     }
 }
+```
+
+## Notes for contributors
+
+The route-corridor implementation was added in response to changes in the Autobahn API that removed reliable junction-number information from warning titles. It is intended to preserve existing configurations while providing a geometry-based alternative for current API data.
+
+When changing filtering logic, please keep these cases in mind:
+
+- long Autobahns with many unrelated warnings
+- curved motorway sections and city rings
+- warnings with `LineString` geometry
+- warnings with only a single coordinate
+- API responses without usable junction numbers
+- temporary API delays or request timeouts
+
+## Credits
+
+Original module: [JockeyDoe/MMM-Autobahn](https://github.com/JockeyDoe/MMM-Autobahn)
+
+Traffic data: German Autobahn traffic API at `verkehr.autobahn.de`.

--- a/README.md
+++ b/README.md
@@ -57,3 +57,57 @@ Description of the config fields
 
 If ```from``` or ```to``` are not defined the module will display the whole road. (This is **not** recommended for long roads with one or two digits f.e. "A7" or "A38")
 
+
+## Route based filtering
+
+The Autobahn API no longer reliably includes junction numbers in warning titles.
+For this reason, `from` and `to` can no longer be used reliably for all roads.
+
+As an alternative, MMM-Autobahn can filter warnings by a configurable route corridor.
+
+A route is defined as a list of latitude/longitude points. The module checks the
+geometry returned by the Autobahn API and only keeps warnings that are within
+the configured corridor.
+
+Example:
+
+```javascript
+{
+    module: "MMM-Autobahn",
+    header: "Verkehrsmeldungen",
+    position: "top_right",
+
+    config: {
+        reloadInterval: 1000 * 60 * 30,
+
+        reloadSchedule: [
+            {
+                start: "05:00",
+                end: "07:00",
+                reloadInterval: 1000 * 60 * 5
+            }
+        ],
+
+        logo_right: true,
+        maxDescriptionLines: 3,
+
+        roads: [
+            {
+                road: "A7",
+                corridorKm: 4,
+
+                route: [
+                    { lat: 53.5220, long: 9.9260 },
+                    { lat: 53.4700, long: 9.9500 },
+                    { lat: 53.4094, long: 9.9931 },
+                    { lat: 53.3837, long: 10.0184 },
+                    { lat: 53.3464, long: 10.0383 }
+                ]
+            },
+
+            {
+                road: "A26"
+            }
+        ]
+    }
+}

--- a/autobahn.css
+++ b/autobahn.css
@@ -1,39 +1,69 @@
 @font-face {
-  font-family: Bahnschrift;
-  src: url("/MMM-Autobahn/BAHNSCHRIFT.TTF");
+    font-family: Bahnschrift;
+    src: url("/MMM-Autobahn/BAHNSCHRIFT.TTF");
 }
 
+#autobahn {
+    max-width: 520px;
+    overflow: hidden;
+}
 
-
-#road-sign {
+.road-sign {
     font-weight: initial;
     color: #ffffff;
     display: inline-block;
     text-align: center;
     font-family: Bahnschrift;
     width: 45px;
-    background-image: url('/MMM-Autobahn/Autobahn_Frame.png');
+    background-color: #003399;
+    background-image:
+        url("/MMM-Autobahn/Autobahn_Frame.png");
+
     background-repeat: no-repeat;
     background-position: center;
     background-size: contain;
+
+    flex: 0 0 45px;
 }
 
 .autobahn-report-element {
-    padding-bottom: 15px;
+    padding-bottom: 12px;
+    overflow: hidden;
 }
 
 .autobahn-report-title {
+    display: flex;
+    align-items: flex-start;
+
     font-weight: 700;
     color: #ffffff;
+
+    line-height: 1.15;
 }
 
 .autobahn-report-subtitle {
-    margin: 0 10px;
+    margin-left: 10px;
+    min-width: 0;
+}
+
+.autobahn-report-body {
+    margin-top: 4px;
+
+    font-size: 0.82em;
+    line-height: 1.18;
+
+    overflow: hidden;
+}
+
+.autobahn-description-line {
+    margin-bottom: 2px;
 }
 
 .jam-length {
+    margin-top: 3px;
+
     font-weight: 100;
-    font-size: 120%;
+    font-size: 100%;
 }
 
 .jam-icon {
@@ -42,5 +72,7 @@
 }
 
 .blocked {
-    font-weight: 400;
+    margin-top: 3px;
+
+    font-weight: 700;
 }

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,75 +1,314 @@
 const NodeHelper = require("node_helper");
-var request = require("native-request");
 
 module.exports = NodeHelper.create({
-    start: function () { },
+
+    start: function () {
+    },
 
     socketNotificationReceived: function (notification, payload) {
-        switch (notification) {
-            case "GET_AUTOBAHN_DATA":
-                let self = this;
-                self.getData(payload);
-                break;
+        if (notification === "GET_AUTOBAHN_DATA") {
+            this.getData(payload);
         }
     },
 
     getData: async function (payload) {
-        let self = this;
-        let roads = payload.config.roads;
+        const roads = payload?.config?.roads || [];
+        const roadData = [];
+        const seen = new Set();
 
-        let roadData = [];
+        let successfulRequests = 0;
 
-        for (let i = 0; i < roads.length; i++) {
-            roadObject = roads[i];
+        for (const roadObject of roads) {
+            try {
+                const warningUrl =
+                    `https://verkehr.autobahn.de/o/autobahn/${roadObject.road}/services/warning`;
 
-            let warningUrl = `https://verkehr.autobahn.de/o/autobahn/${roadObject.road}/services/warning`
+                const response = await fetch(warningUrl, {
+                    signal: AbortSignal.timeout(60000)
+                });
 
-            let response = JSON.parse(await this.doGetRequest(warningUrl));
+                if (!response.ok) {
+                    throw new Error(
+                        `HTTP ${response.status} for ${roadObject.road}`
+                    );
+                }
 
-            let from = roadObject.from;
-            let to = roadObject.to;
+                const data = await response.json();
 
-            response.warning.forEach(warning => {
-                warning.road = roadObject.road;
+                if (!data || !Array.isArray(data.warning)) {
+                    throw new Error(
+                        `Invalid API response for ${roadObject.road}`
+                    );
+                }
 
-                if (from && to) {
-                    let asNumbers = warning.title.match(/\d+\w*/g);
+                successfulRequests++;
 
-                    if (asNumbers.length == 0 || asNumbers.some(num => {
-                        num = new Number(num.replace(/\D+/g, ''))
-                        return num.between(from, to); 
-                    })) {
-                        roadData.push(warning);
+                for (const warning of data.warning) {
+                    warning.road = roadObject.road;
+
+                    if (!this.warningMatchesFilter(warning, roadObject)) {
+                        continue;
                     }
-                } else {
+
+                    const id =
+                        warning.identifier ||
+                        `${warning.road}-${warning.title}-${warning.startTimestamp}`;
+
+                    if (seen.has(id)) {
+                        continue;
+                    }
+
+                    seen.add(id);
                     roadData.push(warning);
                 }
-            });
+
+            } catch (error) {
+                console.error(
+                    `[MMM-Autobahn] Failed to fetch ${roadObject.road}:`,
+                    error.message
+                );
+            }
         }
 
-        self.sendSocketNotification("AUTOBAHN_DATA", roadData);
+        if (roads.length > 0 && successfulRequests === 0) {
+            this.sendSocketNotification(
+                "AUTOBAHN_DATA_ERROR",
+                {
+                    message: "Could not retrieve traffic data."
+                }
+            );
+
+            return;
+        }
+
+        this.sendSocketNotification(
+            "AUTOBAHN_DATA",
+            roadData
+        );
     },
 
-    doGetRequest: async function (url) {
-        return new Promise((resolve, reject) => {
-            let options = {
-                method: 'GET',
-                url,
-                headers: {}
+    warningMatchesFilter: function (warning, roadObject) {
+
+        /*
+         * Preferred filter:
+         * route polyline + configurable corridor.
+         */
+        if (
+            Array.isArray(roadObject.route) &&
+            roadObject.route.length >= 2
+        ) {
+            return this.warningMatchesRoute(
+                warning,
+                roadObject
+            );
+        }
+
+        /*
+         * Backwards-compatible legacy filter.
+         */
+        const from = Number(roadObject.from);
+        const to = Number(roadObject.to);
+
+        if (
+            Number.isFinite(from) &&
+            Number.isFinite(to)
+        ) {
+            return this.warningMatchesLegacyRange(
+                warning,
+                from,
+                to
+            );
+        }
+
+        /*
+         * No filter:
+         * display all warnings for this road.
+         */
+        return true;
+    },
+
+    warningMatchesLegacyRange: function (warning, from, to) {
+
+        /*
+         * Remove the Autobahn number itself before looking
+         * for possible junction numbers.
+         */
+        const title = String(warning?.title || "")
+            .replace(/^\s*A\d+\s*\|\s*/i, "");
+
+        const matches = title.match(/\d+/g) || [];
+
+        /*
+         * Current API titles frequently contain no junction
+         * numbers at all. In that case there is no reliable
+         * legacy value to filter by.
+         */
+        if (matches.length === 0) {
+            return true;
+        }
+
+        const min = Math.min(from, to);
+        const max = Math.max(from, to);
+
+        return matches.some(value => {
+            const number = Number(value);
+
+            return (
+                Number.isFinite(number) &&
+                number >= min &&
+                number <= max
+            );
+        });
+    },
+
+    warningMatchesRoute: function (warning, roadObject) {
+        const route = roadObject.route;
+
+        const corridorKm =
+            Number.isFinite(Number(roadObject.corridorKm))
+                ? Number(roadObject.corridorKm)
+                : 4;
+
+        const warningPoints =
+            this.getWarningPoints(warning);
+
+        if (warningPoints.length === 0) {
+            return false;
+        }
+
+        for (const warningPoint of warningPoints) {
+
+            for (let i = 0; i < route.length - 1; i++) {
+
+                const distance =
+                    this.distancePointToSegmentKm(
+                        warningPoint,
+                        route[i],
+                        route[i + 1]
+                    );
+
+                if (distance <= corridorKm) {
+                    return true;
+                }
             }
+        }
 
-            request.request(options, (error, response) => {
-                if (error)
-                    reject(error);
-                else
-                    resolve(response);
-            });
-        })
+        return false;
+    },
+
+    getWarningPoints: function (warning) {
+
+        /*
+         * GeoJSON LineString:
+         * [longitude, latitude]
+         */
+        if (
+            warning?.geometry?.type === "LineString" &&
+            Array.isArray(warning.geometry.coordinates)
+        ) {
+            return warning.geometry.coordinates
+                .filter(point =>
+                    Array.isArray(point) &&
+                    point.length >= 2 &&
+                    Number.isFinite(Number(point[0])) &&
+                    Number.isFinite(Number(point[1]))
+                )
+                .map(point => ({
+                    lat: Number(point[1]),
+                    long: Number(point[0])
+                }));
+        }
+
+        /*
+         * Fallback if no LineString geometry is available.
+         */
+        if (
+            warning?.coordinate &&
+            Number.isFinite(Number(warning.coordinate.lat)) &&
+            Number.isFinite(Number(warning.coordinate.long))
+        ) {
+            return [{
+                lat: Number(warning.coordinate.lat),
+                long: Number(warning.coordinate.long)
+            }];
+        }
+
+        return [];
+    },
+
+    distancePointToSegmentKm: function (point, start, end) {
+        const earthRadiusKm = 6371;
+
+        const latRef =
+            (
+                Number(point.lat) +
+                Number(start.lat) +
+                Number(end.lat)
+            ) / 3;
+
+        const latRefRad =
+            this.toRadians(latRef);
+
+        /*
+         * Local equirectangular projection.
+         */
+        const project = p => ({
+            x:
+                earthRadiusKm *
+                this.toRadians(Number(p.long)) *
+                Math.cos(latRefRad),
+
+            y:
+                earthRadiusKm *
+                this.toRadians(Number(p.lat))
+        });
+
+        const p = project(point);
+        const a = project(start);
+        const b = project(end);
+
+        const abX = b.x - a.x;
+        const abY = b.y - a.y;
+
+        const apX = p.x - a.x;
+        const apY = p.y - a.y;
+
+        const abLengthSquared =
+            abX * abX +
+            abY * abY;
+
+        if (abLengthSquared === 0) {
+            return Math.hypot(
+                p.x - a.x,
+                p.y - a.y
+            );
+        }
+
+        let t =
+            (
+                apX * abX +
+                apY * abY
+            ) /
+            abLengthSquared;
+
+        t = Math.max(0, Math.min(1, t));
+
+        const nearestX =
+            a.x +
+            t * abX;
+
+        const nearestY =
+            a.y +
+            t * abY;
+
+        return Math.hypot(
+            p.x - nearestX,
+            p.y - nearestY
+        );
+    },
+
+    toRadians: function (value) {
+        return value * Math.PI / 180;
     }
-});
 
-Number.prototype.between = function (a, b) {
-    var min = Math.min.apply(Math, [a, b]),
-        max = Math.max.apply(Math, [a, b]);
-    return this >= min && this <= max;
-};
+});


### PR DESCRIPTION
## Summary

This PR updates MMM-Autobahn for the current Autobahn API, where junction numbers are no longer reliably present in warning titles.

It adds:

* route-based filtering using configurable latitude/longitude points
* a configurable corridor width (`corridorKm`)
* support for API `LineString` geometry with coordinate fallback
* backwards-compatible legacy `from` / `to` filtering without the previous null-match crash
* scheduled reload intervals via `reloadSchedule`
* a 60-second API timeout using native `fetch()`
* clearer UI states for loading, empty results and request errors
* compact warning rendering to reduce overlap with neighbouring MagicMirror modules
* updated documentation and `.gitignore`

## Motivation

Issue #8 documents the underlying problem: the Autobahn API changed and no longer provides junction numbers in a reliable way.

A rectangular coordinate filter was discussed there, but that approach becomes inaccurate for curved motorway sections and city rings. This implementation instead models the relevant road section as a polyline.

A warning is kept when its geometry lies within the configured distance of one of the route segments. This allows the filter to follow curved road sections while avoiding unrelated warnings from the same Autobahn.

Related to #8.

## Compatibility

Existing configurations using `from` and `to` remain supported. If no route or legacy range is configured, warnings for the whole configured road are displayed.

No additional npm dependency is required.

## Testing

Tested on MagicMirror² 2.37.0 on a Raspberry Pi 4.

Verified:

* current A7 API responses with and without junction numbers
* route filtering on a multi-point A7 corridor
* fallback from `LineString` geometry to a single warning coordinate
* filtering out warnings far outside the configured route
* scheduled reload boundaries, including the transition into and out of a 05:00–07:00 five-minute update window
* schedule windows crossing midnight
* successful empty result vs. API request failure handling

The route-scheduler boundary test confirmed that a normal reload cycle does not sleep past the beginning or end of a configured schedule window.
